### PR TITLE
Sync balena master origin master

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,22 @@
+# Contributing
+
+## Development Process
+
+* Clone or fork this repository and use feature branches to develop new features or enhancements
+* Submit a pull request to `mk-rpi/master`
+* Pull requests will be reviewed by the project maintainers, perhaps requesting changes
+* Respond to feedback with additional commit(s)
+* Maintainer approved pull requests will be merged to master
+
+## Testing and Deployment
+
+For contributors with access to the Balena cloud projects, three git remotes should be present on your cloned repository copy:
+
+* `origin/master` - this repository
+* `balena/master` - git remote for the production Balena cloud project
+* `balena/testing` - git remote for the testing Balena cloud project
+
+The general process for testing and deployment:
+
+* `origin/<feature branch>` should be tested before or during a pull request review by pushing to the `balena/testing` remote. This builds the feature branch and deploys the resulting container(s) to the balena test project device fleet.
+* Approved pull requests will be merged into `origin/master` and then pushed to `balena/master` by a project maintainer, which will build and deploy the resulting container(s) to the balena production project device fleet.

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,7 +1,7 @@
 FROM balenalib/%%BALENA_MACHINE_NAME%%-debian:stretch
 ENV INITSYSTEM on
-RUN apt-get update
-RUN apt-get install -qy \
+
+RUN apt-get update && apt-get install -qy \
   autoconf \
   automake \
   clang \
@@ -36,19 +36,17 @@ RUN apt-get install -qy \
   speedtest-cli \
   wget
 
-RUN sed -i 's/DEFAULT@SECLEVEL=2/DEFAULT@SECLEVEL=1/g' /etc/ssl/openssl.cnf
-RUN sed -i 's/MinProtocol = TLSv1.2/MinProtocol = TLSv1.0/g' \
-    /etc/ssl/openssl.cnf
-
-RUN git clone --recursive https://github.com/measurement-kit/libndt.git
-WORKDIR /libndt
-RUN cmake -DLIBNDT_OPENSSL=/usr/bin/ .
-RUN cmake --build .
-
+RUN git clone https://github.com/sivel/speedtest-cli.git
+WORKDIR /speedtest-cli
+RUN python setup.py install
 WORKDIR /
-RUN git clone https://github.com/critzo/mk-rpi.git
+
+RUN git clone --recursive https://github.com/critzo/mk-rpi.git
 WORKDIR /mk-rpi
-COPY --from=build /libndt/libndt-client ./test-runner
+RUN cp WIP/*.dat measurement-kit/
+WORKDIR /mk-rpi/measurement-kit
+RUN ./autogen.sh && ./configure && make && make install && ldconfig
+RUN mv /mk-rpi/measurement-kit/GeoIP* /mk-rpi/test-runner/
 
 WORKDIR /mk-rpi/test-runner
 CMD ["python", "run.py"]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Measurement Kit Rpi (mk-rpi)
 
-`mk-rpi` is a prototype project that automates the setup and installation of network measurement tests on a small computer like a Raspberry Pi, Odroid, or similar. The computer is then connected to a wired ethernet port on a router, where it runs tests regularly, assessing the speed, quality, and other aspects of its connection to the internet.
+`mk-rpi` is a prototype project that automates the setup and installation of network measurement tests on a small computer like a Raspberry Pi, Odroid, or similar. The computer is then connected to an ethernet port or WiFi network, where it runs tests regularly, assessing the speed, quality, and other aspects of its connection to the internet.
 
 Currently, `mk-rpi` supports all tests provided by [Measurement Kit](https://github.com/measurement-kit/measurement-kit), a C++ library providing network measurement tests, and implements one of the supported tests, the Network Diagnostic Tool (NDT). A Python wrapper script (`test-runner/run.py`) runs NDT at regular poisson intervals, saves each test result in JSON format on the computer itself and also submits results to [M-Lab](https://measurementlab.net).
 
@@ -10,7 +10,7 @@ Currently, `mk-rpi` supports all tests provided by [Measurement Kit](https://git
 
 | File/Folder                  | Description |
 |------------------------------|-------------|
-| Dockerfile.template          | Dockerfile used for Resin.io device fleet deployment |
+| Dockerfile.template          | Dockerfile used for Balena.io device fleet deployment |
 | LICENSE.md                   |  |
 | @measurement-kit             | Measurement Kit git sub-module. |
 | README.md                    |  |
@@ -18,72 +18,30 @@ Currently, `mk-rpi` supports all tests provided by [Measurement Kit](https://git
 |   └── ndt-sample-output.txt  |  |
 | setup.sh                     | Setup script for single devices |
 | test-runner                  |  |
-|   ├── run.py                 | Test wrapper for Resin.io device fleet |
+|   ├── run.py                 | Test wrapper for Balena.io device fleet |
 |   └── run-single.py          | Test wrapper for single devices |
 | WIP                          | Work in progress code. |
 
-## Single Device Setup
+## Single Device Setup Alternative
 
-To setup and run `mk-rpi` on a single device, we provide a setup script (`setup.sh`) to configure a newly installed Raspberry Pi 3. Other platforms such as Odroid, or better resourced computers will likely also work provided they are running Debian 9/Stretch. We have tested single device setup with the Rpi3 thus far.
+While it is possible to setup mk-rpi on a single device, the project is currently focused on automated fleet deployment for multiple devices. A similar project, [Murkami](https://github.com/m-lab/murakami), was designed for a single device setup.
 
-* Install the latest [Raspbian OS (Debian 9/Stretch Lite)](https://www.raspberrypi.org/downloads/raspbian/) onto an SD card, insert into your Pi, boot it up, hostname, passwords, SSH access, etc. to your liking.
-* Run updates: `$ sudo apt update && sudo apt upgrade`
-* Install git: `$ sudo apt install git`
-
-The remainder of this guide assumes you are logged into your Pi locally or over SSH, running as the `pi` user with a terminal open to `/home/pi/`.
-
-### Prepare and Install mk-rpi
-
-* Create a folder to store the `mk-rpi` code: `$ mkdir mk-pi && cd mk-pi`
-* Clone this repository: 
-`$ git clone --recursive git@github.com:opentechinstitute/mk-rpi.git . `
-**Note that the ` . ` at the end of this command is not punctuation, but is a part of the command** 
-* Run `setup.sh`: `$ sudo ./setup.sh -u pi` to install required packages, build the Measurement Kit program, and configure the target system. **If you choose to run as a different user than `pi`, replace `pi` with your username in the command above.**
-* To test that everything is working, run this from the root folder of this repo on your pi (/home/pi/mk-pi/): `$ python test-runner/run-single.py`. An NDT test should run, and then a waiting message should appear in the terminal, similar to this: ` ... INFO Sleeping for 481 seconds ...`. 
-* Press Ctrl-c to stop the test runner.
-* When you're ready to have the test run in the background, use screen:
-`$ screen -d -m python test-runner/run-single.py`
-
-### Accessing Test Result Data
-
-For Single Devices, test results are saved on the Rpi in the folder where the test is run. If using the defaults outlined above, that is in `/home/pi/mk-pi/`. Test result filename look something like this: `report-ndt-2017-10-03T191408Z-0.njson`
-
-### Using Screen
-
-We advise you to read the screen manual page: `$ man screen`, but also the commands below will be useful to monitor what screen sessions are running:
-
-* `$ screen -list` - lists all running screen sessions and begins with the screen process ID. Example output: `9281..odroid	(07/30/2017 09:47:25 PM)	(Detached)`
-* `$ screen -r 9281` - reattaches you to a specific screen using the screen process ID
-* Press `Ctrl a d` to detatch from a screen session and leave it running in the background
-* When you log back into your Pi, reconnect to a single running screen session using `$ screen -x`
+We currently recommend using Murkami for a single device, though we plan to merge the two intiatives in the future. 
 
 ## Device Fleet Setup
 
 ### Device Setup and Management
 
-To support and manage multiple measurement devices in the field for specific research projects, we’re using [Resin.io](https://resin.io), which allows us to build our code into a Docker container and push it to a fleet of devices. A "Resin Application” is setup for each type of device architecture. Each application provides a Git remote URL. The file `Dockerfile.template` is used by Resin to build and deploy code to multiple device architectures. This file is not used when using `mk-rpi` on a single device as described above. So far we’ve tested two applications, one for a Raspberry Pi 3 and another for an Odroid C1/C1+. When our code is pushed to the Git remote for Rpi3's a container is built and pushed to our Rpi3 devices. Likewise for the Odroid application's Git remote. 
+To support and manage multiple measurement devices in the field for specific research projects, we’re using [Balena.io](https://balena.io), which allows us to build our code into a Docker container and push it to a fleet of devices. A "Balena Application” is setup for the production fleet, and another for testing. Each application provides a Git remote URL. Pushing to a Balena git remote triggers an application build on Balena's build service, and then deploys the resulting Docker image(s) to devices assigned to each application. The file `Dockerfile.template` is a Docker Compose file, allowing variables to be used to flexibly deploy to different device architectures from the same code base.
 
-Read more about using Resin.io generally in our [blog post](https://opentechinstitute.github.io/2017/10/deploying-and-managing-a-fleet-of-measurement-kit-devices/).
+## Supported Network Measurement Tests
 
-### Data Collection Server and Visualization
+Currently the following tests run automatically on a device running this code when deployed to a Balena.io project:
 
-For our fleet deployment devices, a separate test runner script is used (`/test-runner/run.py`) which saves test results on-device and submits them to M-Lab, but also pushes each result from each device to a central [Prometheus](https://prometheus.io/) server. We also then can visualize the metrics collected by deployed devices using [Grafana](https://grafana.com/).
+* M-Lab tests:
+  * [Network Diagnostic Tool (NDT)](https://www.measurementlab.net/tests/ndt/)
+  * [DASH](https://dl.acm.org/citation.cfm?id=2563671)
+* Speedtest.net
+  * [speedtest-cli](https://github.com/sivel/speedtest-cli)
 
-## Future Development - TO DO LIST
-
-### General TO DOs
-
-* Provide support for additional tests through Measurement Kit
-* Provide support for additional tests from other providers
-* Add Paris Traceroute analysis to use a choice of user-provided URLs or Alexa top sites
-
-### Single Device
-
-* Add a systemd service daemon instead of using screen
-* Add support for an on-device data dashboard
-
-### Device Fleet
-
-* Provide code and instructions on how to set up a third party collector
-* Provide support to post test results to a third party collector
-* Develop a data dashboard with data from other Measurement Kit tests and other open source tests
+M-Lab tests are made available by the [Measurement Kit library](https://measurement-kit.github.io). Measurement Kit also supports the [OONI app](https://ooni.torproject.org/nettest/), and a variety of tests available through Measurement Kit have not yet been implemented in this repository.


### PR DESCRIPTION
Out of necessity or perhaps just individual preference, the build on production fleet is out of sync with master. 

This PR brings `origin/master` back into sync with `balena/master`, updates the README and adds CONTRIBUTING.md, which outlines a specific development and deployment process.